### PR TITLE
Fix variable declaration syntax in backup_and_restore role

### DIFF
--- a/tripleo_ansible/roles/backup_and_restore/backup/tasks/main.yml
+++ b/tripleo_ansible/roles/backup_and_restore/backup/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Create the node backup
   become: true
-  command: rear {{ '-s ' if tripleo_backup_and_restore_rear_simulate else '' }}-d -v mkbackup
+  command: rear {{ '-s ' if "{{ tripleo_backup_and_restore_rear_simulate }}" else '' }}-d -v mkbackup
   register: tripleo_backup_and_restore_rear_output
   when: tripleo_backup_and_restore_rear_output is undefined
   tags:


### PR DESCRIPTION
Found the declaration was incorrect for tripleo_backup_and_restore_rear_simulate variable and fixed it.