### PR TITLE
Update tripleo_os_net_config_mappings.py

### DIFF
--- a/tripleo_ansible/ansible_plugins/modules/tripleo_os_net_config_mappings.py
+++ b/tripleo_ansible/ansible_plugins/modules/tripleo_os_net_config_mappings.py
@@ -98,7 +98,7 @@ def _get_interfaces():
     eth_addr = [
         # cast to lower case for MAC address match
         open('/sys/class/net/{}/address'.format(x)).read().strip().lower()
-        for x in os.listdir('/sys/class/net/')]
+        for x in os.listdir('/sys/class/net/') if os.path.isdir(os.path.join('/sys/class/net/',x))]
     eth_addr = list(filter(None, eth_addr))
 
     return eth_addr


### PR DESCRIPTION
When I run overcloud  deploy, I have an issue  when Tripleo try to create net mapping. I have a file bonding_masters is a file in /sys/class/net/.

To fix it, I propose to check if it is a directory.